### PR TITLE
Fixing the mainClass attribute for the exec-maven-plugin 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.4.0</version>
         <configuration>
-             <mainClass>TableBasics</mainClass>
+             <mainClass>com.microsoft.azure.cosmosdb.tablesample.Main</mainClass>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
so that the command `mvn compile exec:java` works fine as per the docs. I understand that you can still run the fat jar using `java -jar target/storage-java-table-0.0.1-SNAPSHOT-jar-with-dependencies.jar` but it would be nice to have both the configurations consistent